### PR TITLE
Update width binding for DeSelector component

### DIFF
--- a/Components/DeSelector.qml
+++ b/Components/DeSelector.qml
@@ -11,7 +11,7 @@ Controls.ComboBox {
     currentIndex: sessionModel.lastIndex
 
     delegate: Controls.ItemDelegate {
-        width: parent.width
+        width: sessionList.width
         text: model.name || ""
         highlighted: sessionList.highlightedIndex === index
 


### PR DESCRIPTION
Required to reference the parent object by name to avoid nulls and the dropdown selection for the session from being ignored. Having both Niri and WangoWC sessions after successfully logging into Niri I could not get into MangoWC without this fix, it would always load Niri.