### PR TITLE
feat: migrate theme from Qt5 to Qt6

### DIFF
--- a/Components/CardBottom.qml
+++ b/Components/CardBottom.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtGraphicalEffects 1.12
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import QtQuick.Layouts
 
 Item {
     id: loginCard

--- a/Components/Clock.qml
+++ b/Components/Clock.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtQuick 2.15
+import QtQuick
 
 Item {
     // smooth animation

--- a/Components/ControlButton.qml
+++ b/Components/ControlButton.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Button {
     id: root

--- a/Components/DeSelector.qml
+++ b/Components/DeSelector.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Controls 2.15 as Controls
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Layouts
 
 Controls.ComboBox {
     id: sessionList

--- a/Components/Icon.qml
+++ b/Components/Icon.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtQuick 2.15
+import QtQuick
 
 Text {
     property string utf8Code: "\uf06a"

--- a/Components/IconButton.qml
+++ b/Components/IconButton.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Button {
     // Defaults that can still be overridden

--- a/Components/LoginControls.qml
+++ b/Components/LoginControls.qml
@@ -1,7 +1,6 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
-import SddmComponents 2.0
+import QtQuick
+import QtQuick.Layouts
 
 Item {
     id: root

--- a/Components/PasswordField.qml
+++ b/Components/PasswordField.qml
@@ -1,7 +1,6 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
-import SddmComponents 2.0
+import QtQuick
+import QtQuick.Layouts
 
 Rectangle {
     id: root
@@ -68,7 +67,7 @@ Rectangle {
             text: ""
             onAccepted: sddm.login(cachedUsers[userIndex].name, passwordField.text, Global.currentSessionIndex)
             Layout.fillWidth: true
-            Keys.onPressed: {
+            Keys.onPressed: (event) => {
                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                     sddm.login(cachedUsers[userIndex].name, passwordField.text, Global.currentSessionIndex);
                     event.accepted = true;

--- a/Components/UserAvatar.qml
+++ b/Components/UserAvatar.qml
@@ -1,7 +1,6 @@
 import ".."
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import SddmComponents 2.0
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: avatar

--- a/Components/UserCard.qml
+++ b/Components/UserCard.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import QtQuick.Layouts
 
 Rectangle {
     // ========= Public API =========

--- a/Components/UserSelector.qml
+++ b/Components/UserSelector.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtGraphicalEffects 1.12
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import QtQuick.Controls
 
 Item {
     // ▲ UP

--- a/Globals.qml
+++ b/Globals.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Window
 pragma Singleton
 
 QtObject {

--- a/Main.qml
+++ b/Main.qml
@@ -1,5 +1,5 @@
-import QtGraphicalEffects 1.12
-import QtQuick 2.15
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Rectangle {
     id: root

--- a/README.md
+++ b/README.md
@@ -22,18 +22,10 @@ and [Noctalia Dev](https://noctalia.dev/)
 
 > [!NOTE]
 > Theme Dependencies
-> `qt5-graphicaleffects` and `qt5-quickcontrols2`
+> `qt6-5compat` and `qt6-declarative`
 > Misc Dependencies (installer)
 > `jq` - used for handling .json mutations (wallpaper-sync)
 > `awk` - use for handling .conf mutations (installer)
-
-> [!NOTE]
-> If you are using Wayland you might need
-> to also install `qt5-wayland`
-
-### Current W.I.P
-
-- Migrate from qt5 to qt6
 
 ## Installation
 
@@ -121,7 +113,7 @@ sudo chmod 666 "/usr/share/sddm/themes/noctalia/Assets/background.png"
 ## Test theme installation
 
 ```sh
-sddm-greeter --test-mode --theme /usr/share/sddm/themes/noctalia
+sddm-greeter-qt6 --test-mode --theme /usr/share/sddm/themes/noctalia
 ```
 
 ## Configuration

--- a/installer/steps/step_finish.sh
+++ b/installer/steps/step_finish.sh
@@ -3,7 +3,7 @@
 render_header "✅ Installation complete!"
 
 if ask_yes_no "Would you like to test your current theme?"; then
-  run_cmd sudo -u $SUDO_USER sddm-greeter --test-mode --theme $DEST_DIR
+  run_cmd sudo -u $SUDO_USER sddm-greeter-qt6 --test-mode --theme $DEST_DIR
 fi
 
 render_subheader "Goodbye cruel world!"

--- a/installer/steps/step_install_color.sh
+++ b/installer/steps/step_install_color.sh
@@ -7,6 +7,12 @@ render_header "🧩 Installing Noctalia-Shell color sync..."
 run_cmd cp "$PROJECT_ROOT/theme.template.conf" $DEST_DIR
 run_cmd chmod 666 "$DEST_DIR/theme.conf"
 
+if [[ ! -f "$user_template" ]]; then
+  run_cmd mkdir -p "$(dirname "$user_template")"
+  run_cmd touch "$user_template"
+  run_cmd chown "$SUDO_USER" "$user_template"
+fi
+
 run_cmd ini_set $user_template templates.sddm input_path "\"$DEST_DIR/theme.template.conf\""
 run_cmd ini_set $user_template templates.sddm output_path "\"$DEST_DIR/theme.conf\""
 

--- a/installer/steps/step_sddm_deps.sh
+++ b/installer/steps/step_sddm_deps.sh
@@ -4,9 +4,9 @@ source "$ROOT_DIR/lib/deps.sh"
 DEPENDENCIES=(
   "cmd:sddm"
   "cmd:awk"
-  "cmd:sddm-greeter"
-  "pkg:qt5-quickcontrols2"
-  "pkg:qt5-graphicaleffects"
+  "cmd:sddm-greeter-qt6"
+  "pkg:qt6-5compat"
+  "pkg:qt6-declarative"
 )
 
 echo

--- a/metadata.desktop
+++ b/metadata.desktop
@@ -10,3 +10,4 @@ MainScript=Main.qml
 ConfigFile=theme.conf
 Theme-Id=noctalia
 Theme-API=2.0
+QtVersion=6


### PR DESCRIPTION
- Remove version numbers from all QML imports (Qt6 style)
- Replace QtGraphicalEffects with Qt5Compat.GraphicalEffects
- Remove unused SddmComponents 2.0 imports
- Fix deprecated implicit signal handler parameter (Keys.onPressed)
- Add QtVersion=6 to metadata.desktop
- Update installer dependencies to qt6-5compat, qt6-declarative
- Update installer/finish to use sddm-greeter-qt6
- Create user-templates.toml if missing during color sync install
- Update README.md with Qt6 dependencies and test command