### PR TITLE
Fedora support & Noctalia theme integration and some fixes

### DIFF
--- a/Components/CardBottom.qml
+++ b/Components/CardBottom.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 

--- a/Components/UserAvatar.qml
+++ b/Components/UserAvatar.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtGraphicalEffects 1.15
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.15
 import SddmComponents 2.0
 

--- a/Components/UserCard.qml
+++ b/Components/UserCard.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtGraphicalEffects 1.15
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 

--- a/Components/UserSelector.qml
+++ b/Components/UserSelector.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 

--- a/Main.qml
+++ b/Main.qml
@@ -1,4 +1,4 @@
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.15
 
 Rectangle {

--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ and [Noctalia Dev](https://noctalia.dev/)
 ## Features
 
 - Multiple user support (clicking top card allows you to switch between users)
+- Standalone SDDM theme using `theme.conf`
 - Color sync with Noctalia-Shell via user-templates (optional)
 - Script for installation / removal `./installer/install.sh`
   - theme directory: `/usr/share/sddm/themes/noctalia`
   - SDDM configuration: `/etc/sddm.conf.d/noctalia.conf`
   - shell integration: `~/.config/noctalia/user-templates.toml` (optional)
 - Wallpaper sync with Noctalia-Shell via script `sync-shell-wallpaper.sh` (optional) (Tested Noctalia Shell <= v4.7.5 )
-- Various customizable settings via `theme.config` or
-  `theme.template.config` see [Configuration](#configuration) section
+- Various customizable settings via `theme.conf` or
+  `theme.template.conf` see [Configuration](#configuration) section
 
 > [!NOTE]
 > Theme Dependencies
@@ -55,6 +56,11 @@ You will be prompted during the installation for the following optional features
 If you install / configure the sync "features" you will need to change
 the color scheme and wallpaper once for changes to take effect.
 
+The optional Noctalia sync steps assume a mutable system install under
+`/usr/share/sddm/themes/noctalia`. Image-based or read-only distro packages
+should install the theme normally and choose their own writable output paths for
+generated config or synced assets.
+
 After installation you can use the [Test command](#test-theme-installation)
 to view results
 
@@ -78,11 +84,12 @@ Current=noctalia
 
 ### Noctalia-Shell (optional)
 
-Set file permissions for theme.conf (needed for Noctalia-Shell)
+The theme works without Noctalia. In that mode, edit the installed
+`theme.conf` directly and leave `theme.template.conf` unused.
 
-```sh
-sudo chmod 666 "/usr/share/sddm/themes/noctalia/theme.conf"
-```
+Noctalia users can enable user templates and render `theme.template.conf` to the
+installed theme's `theme.conf`. The SDDM greeter only reads the installed theme
+config; it does not read `~/.config/noctalia` directly.
 
 ### Color-Sync
 
@@ -97,6 +104,11 @@ input_path = "/usr/share/sddm/themes/noctalia/theme.template.conf"
 output_path = "/usr/share/sddm/themes/noctalia/theme.conf"
 ```
 
+On mutable installs, the installer makes the installed `theme.conf` writable by
+the installing user for this output path. If your distro packages the theme in a
+read-only location, keep `theme.template.conf` as the source and point Noctalia
+at a packaging-specific writable output path instead.
+
 ### Wallpaper-sync
 
 Open Noctalia-Shell `Settings > Hooks` and add the following inside
@@ -106,11 +118,10 @@ Open Noctalia-Shell `Settings > Hooks` and add the following inside
 /usr/share/sddm/themes/noctalia/sync-shell-wallpaper.sh
 ```
 
-Set file permissions for background.png (gets overwritten by the script)
-
-```sh
-sudo chmod 666 "/usr/share/sddm/themes/noctalia/Assets/background.png"
-```
+Wallpaper sync copies the selected wallpaper over the installed
+`Assets/background.png`. It only works when that installed asset path is
+writable by the hook. On immutable or image-based distros, package the theme and
+adjust the hook or packaging to use a distro-owned writable target path.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Current=noctalia
 
 ### Noctalia-Shell (optional)
 
-Make theme.conf writable by your user (needed for Noctalia-Shell)
+Set file permissions for theme.conf (needed for Noctalia-Shell)
 
 ```sh
-sudo chown "$USER" "/usr/share/sddm/themes/noctalia/theme.conf"
+sudo chmod 666 "/usr/share/sddm/themes/noctalia/theme.conf"
 ```
 
 ### Color-Sync
@@ -97,8 +97,6 @@ input_path = "/usr/share/sddm/themes/noctalia/theme.template.conf"
 output_path = "/usr/share/sddm/themes/noctalia/theme.conf"
 ```
 
-This assumes the installed theme.conf is writable by Noctalia-Shell.
-
 ### Wallpaper-sync
 
 Open Noctalia-Shell `Settings > Hooks` and add the following inside
@@ -108,14 +106,11 @@ Open Noctalia-Shell `Settings > Hooks` and add the following inside
 /usr/share/sddm/themes/noctalia/sync-shell-wallpaper.sh
 ```
 
-Make background.png writable by your user (gets overwritten by the script)
+Set file permissions for background.png (gets overwritten by the script)
 
 ```sh
-sudo chown "$USER" "/usr/share/sddm/themes/noctalia/Assets/background.png"
+sudo chmod 666 "/usr/share/sddm/themes/noctalia/Assets/background.png"
 ```
-
-If the installed theme path is read-only, adjust the writable output path in
-your package or hook setup.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ and [Noctalia Dev](https://noctalia.dev/)
 - Color sync with Noctalia-Shell via user-templates (optional)
 - Script for installation / removal `./installer/install.sh`
   - theme directory: `/usr/share/sddm/themes/noctalia`
-  - SDDM configuration : `/etc/sddm.conf.d/noctalia.conf`
+  - SDDM configuration : `/etc/sddm.conf` if default is not found
+    `/etc/sddm.conf.d/noctalia.conf` will be created
   - shell integration: `~/.config/noctalia/user-templates.toml` (optional)
 - Wallpaper sync with Noctalia-Shell via script `sync-shell-wallpaper.sh` (optional) (Tested Noctalia Shell <= v4.7.5 )
 - Various customizable settings via `theme.config` or
@@ -67,7 +68,8 @@ to view results
 
 Copy directory to sddm themes with `sudo cp -r noctalia /usr/share/sddm/themes`
 
-Activate theme by creating or editing `/etc/sddm.conf.d/noctalia.conf` with:
+Activate theme by opening either default `/etc/sddm.conf` or `/etc/sddm.conf.d/noctalia.conf`
+and changing the `Current` key to the following:
 
 ```ini
 [Theme]

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ and [Noctalia Dev](https://noctalia.dev/)
 ## Features
 
 - Multiple user support (clicking top card allows you to switch between users)
-- Standalone SDDM theme using `theme.conf`
 - Color sync with Noctalia-Shell via user-templates (optional)
 - Script for installation / removal `./installer/install.sh`
   - theme directory: `/usr/share/sddm/themes/noctalia`
-  - SDDM configuration: `/etc/sddm.conf.d/noctalia.conf`
+  - SDDM configuration : `/etc/sddm.conf.d/noctalia.conf`
   - shell integration: `~/.config/noctalia/user-templates.toml` (optional)
 - Wallpaper sync with Noctalia-Shell via script `sync-shell-wallpaper.sh` (optional) (Tested Noctalia Shell <= v4.7.5 )
-- Various customizable settings via `theme.conf` or
-  `theme.template.conf` see [Configuration](#configuration) section
+- Various customizable settings via `theme.config` or
+  `theme.template.config` see [Configuration](#configuration) section
 
 > [!NOTE]
 > Theme Dependencies
@@ -29,9 +28,7 @@ and [Noctalia Dev](https://noctalia.dev/)
 > `awk` - use for handling .conf mutations (installer)
 
 > [!NOTE]
-> The theme targets Qt6 SDDM greeters. The installer test command prefers
-> `sddm-greeter-qt6` and falls back to `sddm-greeter` when the Qt6 binary is
-> not available separately.
+> The theme targets Qt6 SDDM greeters.
 
 ## Installation
 
@@ -56,11 +53,6 @@ You will be prompted during the installation for the following optional features
 If you install / configure the sync "features" you will need to change
 the color scheme and wallpaper once for changes to take effect.
 
-The optional Noctalia sync steps assume a mutable system install under
-`/usr/share/sddm/themes/noctalia`. Image-based or read-only distro packages
-should install the theme normally and choose their own writable output paths for
-generated config or synced assets.
-
 After installation you can use the [Test command](#test-theme-installation)
 to view results
 
@@ -84,12 +76,11 @@ Current=noctalia
 
 ### Noctalia-Shell (optional)
 
-The theme works without Noctalia. In that mode, edit the installed
-`theme.conf` directly and leave `theme.template.conf` unused.
+Make theme.conf writable by your user (needed for Noctalia-Shell)
 
-Noctalia users can enable user templates and render `theme.template.conf` to the
-installed theme's `theme.conf`. The SDDM greeter only reads the installed theme
-config; it does not read `~/.config/noctalia` directly.
+```sh
+sudo chown "$USER" "/usr/share/sddm/themes/noctalia/theme.conf"
+```
 
 ### Color-Sync
 
@@ -104,10 +95,7 @@ input_path = "/usr/share/sddm/themes/noctalia/theme.template.conf"
 output_path = "/usr/share/sddm/themes/noctalia/theme.conf"
 ```
 
-On mutable installs, the installer makes the installed `theme.conf` writable by
-the installing user for this output path. If your distro packages the theme in a
-read-only location, keep `theme.template.conf` as the source and point Noctalia
-at a packaging-specific writable output path instead.
+This assumes the installed theme.conf is writable by Noctalia-Shell.
 
 ### Wallpaper-sync
 
@@ -118,10 +106,14 @@ Open Noctalia-Shell `Settings > Hooks` and add the following inside
 /usr/share/sddm/themes/noctalia/sync-shell-wallpaper.sh
 ```
 
-Wallpaper sync copies the selected wallpaper over the installed
-`Assets/background.png`. It only works when that installed asset path is
-writable by the hook. On immutable or image-based distros, package the theme and
-adjust the hook or packaging to use a distro-owned writable target path.
+Make background.png writable by your user (gets overwritten by the script)
+
+```sh
+sudo chown "$USER" "/usr/share/sddm/themes/noctalia/Assets/background.png"
+```
+
+If the installed theme path is read-only, adjust the writable output path in
+your package or hook setup.
 
 </details>
 
@@ -131,7 +123,7 @@ adjust the hook or packaging to use a distro-owned writable target path.
 sddm-greeter-qt6 --test-mode --theme /usr/share/sddm/themes/noctalia
 ```
 
-If your distro still exposes the greeter as `sddm-greeter`, use:
+Fallback command:
 
 ```sh
 sddm-greeter --test-mode --theme /usr/share/sddm/themes/noctalia

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ and [Noctalia Dev](https://noctalia.dev/)
 - Color sync with Noctalia-Shell via user-templates (optional)
 - Script for installation / removal `./installer/install.sh`
   - theme directory: `/usr/share/sddm/themes/noctalia`
-  - SDDM configuration : `/etc/sddm.conf` if default is not found you will be prompted
-    to select a .conf file from within `/etc/sddm.conf.d/` directory
+  - SDDM configuration: `/etc/sddm.conf.d/noctalia.conf`
   - shell integration: `~/.config/noctalia/user-templates.toml` (optional)
 - Wallpaper sync with Noctalia-Shell via script `sync-shell-wallpaper.sh` (optional) (Tested Noctalia Shell <= v4.7.5 )
 - Various customizable settings via `theme.config` or
@@ -22,18 +21,16 @@ and [Noctalia Dev](https://noctalia.dev/)
 
 > [!NOTE]
 > Theme Dependencies
-> `qt5-graphicaleffects` and `qt5-quickcontrols2`
+> Fedora: `sddm`, `sddm-wayland-generic`, `qt6-qt5compat`, `qt6-qtsvg`
+> Arch/CachyOS: `sddm`, `qt6-5compat`, `qt6-svg`
 > Misc Dependencies (installer)
 > `jq` - used for handling .json mutations (wallpaper-sync)
 > `awk` - use for handling .conf mutations (installer)
 
 > [!NOTE]
-> If you are using Wayland you might need
-> to also install `qt5-wayland`
-
-### Current W.I.P
-
-- Migrate from qt5 to qt6
+> The theme targets Qt6 SDDM greeters. The installer test command prefers
+> `sddm-greeter-qt6` and falls back to `sddm-greeter` when the Qt6 binary is
+> not available separately.
 
 ## Installation
 
@@ -72,8 +69,7 @@ to view results
 
 Copy directory to sddm themes with `sudo cp -r noctalia /usr/share/sddm/themes`
 
-Activate theme by opening either default `/etc/sddm.conf` or `/etc/sddm.conf.d/CUSTOM.conf`
-and changing the `Current` key to the following:
+Activate theme by creating or editing `/etc/sddm.conf.d/noctalia.conf` with:
 
 ```ini
 [Theme]
@@ -119,6 +115,12 @@ sudo chmod 666 "/usr/share/sddm/themes/noctalia/Assets/background.png"
 </details>
 
 ## Test theme installation
+
+```sh
+sddm-greeter-qt6 --test-mode --theme /usr/share/sddm/themes/noctalia
+```
+
+If your distro still exposes the greeter as `sddm-greeter`, use:
 
 ```sh
 sddm-greeter --test-mode --theme /usr/share/sddm/themes/noctalia

--- a/installer/lib/deps.sh
+++ b/installer/lib/deps.sh
@@ -18,6 +18,16 @@ is_installed() {
 
   case "$type" in
   cmd) is_installed_cmd "$name" ;;
+  cmd_any)
+    local cmd
+    IFS=',' read -ra commands <<<"$name"
+    for cmd in "${commands[@]}"; do
+      if is_installed_cmd "$cmd"; then
+        return 0
+      fi
+    done
+    return 1
+    ;;
   pkg) is_installed_pkg "$name" ;;
   *)
     echo "Unknown dependency type: $type"

--- a/installer/lib/pkg.sh
+++ b/installer/lib/pkg.sh
@@ -14,6 +14,30 @@ detect_package_manager() {
   fi
 }
 
+package_dependencies() {
+  case "$PKG_MANAGER" in
+  dnf | yum)
+    printf '%s\n' \
+      "pkg:sddm" \
+      "pkg:sddm-wayland-generic" \
+      "pkg:qt6-qt5compat" \
+      "pkg:qt6-qtsvg"
+    ;;
+  pacman)
+    printf '%s\n' \
+      "pkg:sddm" \
+      "pkg:qt6-5compat" \
+      "pkg:qt6-svg"
+    ;;
+  apt)
+    printf '%s\n' \
+      "pkg:sddm" \
+      "pkg:qml6-module-qt5compat-graphicaleffects" \
+      "pkg:qml6-module-qtsvg"
+    ;;
+  esac
+}
+
 install_package() {
   local name="${1#*:}"
   case "$PKG_MANAGER" in

--- a/installer/lib/utils.sh
+++ b/installer/lib/utils.sh
@@ -38,18 +38,43 @@ option_exists() {
 }
 
 set_sddm_config() {
-  # Get sddm config file
-  if [[ ! -f $SDDM_CONF ]]; then
-    echo "Select your sddm config file"
-    cd $SDDM_CONF_DIR
-    select file in *; do
-      if [[ -f "$file" ]]; then
-        SDDM_CONF="$SDDM_CONF_DIR/$file"
-        break
-      else
-        echo "Invalid choice"
-      fi
+  local theme_conf="$SDDM_CONF_DIR/$PROJECT_NAME.conf"
+
+  if [[ -f "$theme_conf" ]]; then
+    SDDM_CONF="$theme_conf"
+  elif [[ -f "$SDDM_CONF" ]]; then
+    SDDM_CONF="$SDDM_CONF"
+  else
+    SDDM_CONF="$theme_conf"
+  fi
+}
+
+find_current_sddm_theme() {
+  local conf
+  local current=""
+
+  if [[ -f /etc/sddm.conf ]]; then
+    current=$(ini_get /etc/sddm.conf Theme Current)
+  fi
+
+  if [[ -z "$current" && -d /etc/sddm.conf.d ]]; then
+    for conf in /etc/sddm.conf.d/*.conf; do
+      [[ -f "$conf" ]] || continue
+      current=$(ini_get "$conf" Theme Current)
+      [[ -n "$current" ]] && break
     done
+  fi
+
+  printf '%s\n' "$current"
+}
+
+sddm_greeter_cmd() {
+  if command_exists sddm-greeter-qt6; then
+    echo sddm-greeter-qt6
+  elif command_exists sddm-greeter; then
+    echo sddm-greeter
+  else
+    return 1
   fi
 }
 

--- a/installer/steps/step_finish.sh
+++ b/installer/steps/step_finish.sh
@@ -3,7 +3,8 @@
 render_header "✅ Installation complete!"
 
 if ask_yes_no "Would you like to test your current theme?"; then
-  run_cmd sudo -u $SUDO_USER sddm-greeter --test-mode --theme $DEST_DIR
+  GREETER_CMD=$(sddm_greeter_cmd)
+  run_cmd sudo -u "$SUDO_USER" "$GREETER_CMD" --test-mode --theme "$DEST_DIR"
 fi
 
 render_subheader "Goodbye cruel world!"

--- a/installer/steps/step_install_base.sh
+++ b/installer/steps/step_install_base.sh
@@ -18,22 +18,14 @@ render_info "Theme files copied successfuly!"
 
 render_subheader "⚙️ Activating theme..."
 
-# Get sddm config file
-if [[ ! -f $SDDM_CONF ]]; then
-  echo "Select your sddm config file"
-  cd $SDDM_CONF_DIR
-  select file in *; do
-    if [[ -f "$file" ]]; then
-      SDDM_CONF="$SDDM_CONF_DIR/$file"
-      break
-    else
-      echo "Invalid choice"
-    fi
-  done
-fi
+run_cmd mkdir -p "$SDDM_CONF_DIR"
+SDDM_CONF="$SDDM_CONF_DIR/$PROJECT_NAME.conf"
+run_cmd touch "$SDDM_CONF"
 
 # Set theme to noctalia
-CUR_THEME=$(ini_get $SDDM_CONF Theme Current)
-run_cmd ini_set $SDDM_CONF Theme Current.bak $CUR_THEME
-run_cmd ini_set $SDDM_CONF Theme Current $PROJECT_NAME
+CUR_THEME=$(find_current_sddm_theme)
+if [[ -n "$CUR_THEME" && "$CUR_THEME" != "$PROJECT_NAME" ]]; then
+  run_cmd ini_set "$SDDM_CONF" Theme Current.bak "$CUR_THEME"
+fi
+run_cmd ini_set "$SDDM_CONF" Theme Current "$PROJECT_NAME"
 render_info "Theme activated!"

--- a/installer/steps/step_install_base.sh
+++ b/installer/steps/step_install_base.sh
@@ -18,8 +18,10 @@ render_info "Theme files copied successfuly!"
 
 render_subheader "⚙️ Activating theme..."
 
-run_cmd mkdir -p "$SDDM_CONF_DIR"
-SDDM_CONF="$SDDM_CONF_DIR/$PROJECT_NAME.conf"
+if [[ ! -f "$SDDM_CONF" ]]; then
+  run_cmd mkdir -p "$SDDM_CONF_DIR"
+  SDDM_CONF="$SDDM_CONF_DIR/$PROJECT_NAME.conf"
+fi
 run_cmd touch "$SDDM_CONF"
 
 # Set theme to noctalia

--- a/installer/steps/step_install_color.sh
+++ b/installer/steps/step_install_color.sh
@@ -7,11 +7,10 @@ render_header "🧩 Installing Noctalia-Shell color sync..."
 run_cmd cp "$PROJECT_ROOT/theme.template.conf" $DEST_DIR
 run_cmd mkdir -p "$(dirname "$user_template")"
 run_cmd touch "$user_template"
-run_cmd chown "$SUDO_USER" "$DEST_DIR/theme.conf"
+run_cmd chmod 666 "$DEST_DIR/theme.conf"
 
 run_cmd ini_set $user_template templates.sddm input_path "\"$DEST_DIR/theme.template.conf\""
 run_cmd ini_set $user_template templates.sddm output_path "\"$DEST_DIR/theme.conf\""
 
 run_cmd chown $SUDO_USER $user_template
-render_info "This assumes a mutable install where Noctalia can write $DEST_DIR/theme.conf."
 render_info "Remember to activate user-templates in noctalia-shell and refresh your theme to update sddm!"

--- a/installer/steps/step_install_color.sh
+++ b/installer/steps/step_install_color.sh
@@ -5,10 +5,13 @@ user_template="/home/$SUDO_USER/.config/noctalia/user-templates.toml"
 render_header "🧩 Installing Noctalia-Shell color sync..."
 
 run_cmd cp "$PROJECT_ROOT/theme.template.conf" $DEST_DIR
-run_cmd chmod 666 "$DEST_DIR/theme.conf"
+run_cmd mkdir -p "$(dirname "$user_template")"
+run_cmd touch "$user_template"
+run_cmd chown "$SUDO_USER" "$DEST_DIR/theme.conf"
 
 run_cmd ini_set $user_template templates.sddm input_path "\"$DEST_DIR/theme.template.conf\""
 run_cmd ini_set $user_template templates.sddm output_path "\"$DEST_DIR/theme.conf\""
 
 run_cmd chown $SUDO_USER $user_template
+render_info "This assumes a mutable install where Noctalia can write $DEST_DIR/theme.conf."
 render_info "Remember to activate user-templates in noctalia-shell and refresh your theme to update sddm!"

--- a/installer/steps/step_install_wallpaper.sh
+++ b/installer/steps/step_install_wallpaper.sh
@@ -4,8 +4,10 @@
 render_header "🧩 Installing Noctalia-Shell wallpaper sync..."
 
 run_cmd cp "$PROJECT_ROOT/sync-shell-wallpaper.sh" $DEST_DIR
+run_cmd chown "$SUDO_USER" "$DEST_DIR/Assets/background.png"
 
 render_info "Add the following script to noctalia hooks and change your wallpaper after"
 echo "------------------------------------------------"
 echo "$DEST_DIR/sync-shell-wallpaper.sh"
 echo "------------------------------------------------"
+render_info "This assumes a mutable install where the hook can write $DEST_DIR/Assets/background.png."

--- a/installer/steps/step_install_wallpaper.sh
+++ b/installer/steps/step_install_wallpaper.sh
@@ -4,10 +4,8 @@
 render_header "🧩 Installing Noctalia-Shell wallpaper sync..."
 
 run_cmd cp "$PROJECT_ROOT/sync-shell-wallpaper.sh" $DEST_DIR
-run_cmd chown "$SUDO_USER" "$DEST_DIR/Assets/background.png"
 
 render_info "Add the following script to noctalia hooks and change your wallpaper after"
 echo "------------------------------------------------"
 echo "$DEST_DIR/sync-shell-wallpaper.sh"
 echo "------------------------------------------------"
-render_info "This assumes a mutable install where the hook can write $DEST_DIR/Assets/background.png."

--- a/installer/steps/step_sddm_deps.sh
+++ b/installer/steps/step_sddm_deps.sh
@@ -2,12 +2,11 @@
 source "$ROOT_DIR/lib/deps.sh"
 
 DEPENDENCIES=(
-  "cmd:sddm"
   "cmd:awk"
-  "cmd:sddm-greeter"
-  "pkg:qt5-quickcontrols2"
-  "pkg:qt5-graphicaleffects"
+  "cmd_any:sddm-greeter-qt6,sddm-greeter"
 )
+mapfile -t PACKAGE_DEPENDENCIES < <(package_dependencies)
+DEPENDENCIES+=("${PACKAGE_DEPENDENCIES[@]}")
 
 echo
 render_header "📦 Checking dependencies..."
@@ -41,6 +40,10 @@ echo
 
 if ask_yes_no "Install missing dependencies?"; then
   for dep in "${MISSING[@]}"; do
+    if [[ "$dep" != pkg:* ]]; then
+      echo "⚠️ ${dep#*:} must be installed manually"
+      continue
+    fi
     echo "⬇️ Installing $dep..."
     install_package "$dep"
   done

--- a/installer/steps/step_uninstall.sh
+++ b/installer/steps/step_uninstall.sh
@@ -5,8 +5,15 @@ render_header "🗑️ Uninstalling $PROJECT_NAME sddm theme!"
 # Get sddm config file
 run_cmd set_sddm_config
 OLD_THEME=$(ini_get $SDDM_CONF Theme Current.bak)
-run_cmd ini_set $SDDM_CONF Theme Current $OLD_THEME
-run_cmd ini_del $SDDM_CONF Theme Current.bak
+if [[ -n "$OLD_THEME" ]]; then
+  run_cmd ini_set $SDDM_CONF Theme Current $OLD_THEME
+  run_cmd ini_del $SDDM_CONF Theme Current.bak
+else
+  run_cmd ini_del $SDDM_CONF Theme Current
+  if [[ "$SDDM_CONF" == "$SDDM_CONF_DIR/$PROJECT_NAME.conf" ]]; then
+    run_cmd rm -f "$SDDM_CONF"
+  fi
+fi
 
 # remove theme folder
 run_cmd rm -rf $DEST_DIR

--- a/sync-shell-wallpaper.sh
+++ b/sync-shell-wallpaper.sh
@@ -8,16 +8,20 @@ JSON_FILE="$HOME/.cache/noctalia/wallpapers.json"
 sleep 2
 
 WALLPAPER=$(jq -r '
-    if (.wallpapers | length) > 0 then
-        (.wallpapers | to_entries[0].value) as $value
-        | if ($value | type) == "object" then
-            ($value.dark // $value.light)
-          else
-            $value
-          end
-    else
-        .defaultWallpaper
-    end
+    def valid_path:
+        select(type == "string" and length > 0);
+
+    def wallpaper_value:
+        if type == "object" then
+            (.dark // .light // empty) | valid_path
+        else
+            valid_path
+        end;
+
+    ((.wallpapers // {})
+        | to_entries[]
+        | .value
+        | wallpaper_value) // (.defaultWallpaper | valid_path) // empty
 ' "$JSON_FILE")
 
 if [[ -z "$WALLPAPER" || "$WALLPAPER" == "null" ]]; then


### PR DESCRIPTION
This adds Fedora support and updates the theme/installer for Qt6 SDDM

 -use `Qt5Compat.GraphicalEffects` QML imports
- add distro-specific Qt6 dependencies for Fedora, Arch/CachyOS, and apt-based systems
- preserve `/etc/sddm.conf` when present; otherwise create `/etc/sddm.conf.d/noctalia.conf`

