### PR TITLE
Migrate theme to Qt6 and harden color/wallpaper sync

### DIFF
--- a/Components/CardBottom.qml
+++ b/Components/CardBottom.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtGraphicalEffects 1.12
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
 
 Item {
     id: loginCard
@@ -27,16 +27,15 @@ Item {
         opacity: Global.cardOpacity
         layer.enabled: Global.dropShadows
 
-        layer.effect: DropShadow {
+        layer.effect: MultiEffect {
             id: cardShadow
 
-            anchors.fill: cardBg
-            source: cardBg
-            horizontalOffset: 0
-            verticalOffset: 0
-            radius: 16
-            samples: 24
-            color: "#40000000"
+            shadowEnabled: true
+            shadowColor: "#40000000"
+            shadowHorizontalOffset: 0
+            shadowVerticalOffset: 0
+            shadowBlur: 1.0
+            blurMax: 16
         }
 
     }

--- a/Components/Clock.qml
+++ b/Components/Clock.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtQuick 2.15
+import QtQuick
 
 Item {
     // smooth animation

--- a/Components/ControlButton.qml
+++ b/Components/ControlButton.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Button {
     id: root

--- a/Components/DeSelector.qml
+++ b/Components/DeSelector.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Controls 2.15 as Controls
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Layouts
 
 Controls.ComboBox {
     id: sessionList

--- a/Components/Icon.qml
+++ b/Components/Icon.qml
@@ -1,5 +1,5 @@
 import ".."
-import QtQuick 2.15
+import QtQuick
 
 Text {
     property string utf8Code: "\uf06a"

--- a/Components/IconButton.qml
+++ b/Components/IconButton.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Button {
     // Defaults that can still be overridden

--- a/Components/IconButton.qml
+++ b/Components/IconButton.qml
@@ -11,7 +11,7 @@ Button {
     property color bgColor: Global.mSurfaceVariant
     property color textColor: Global.mOnSurfaceVariant
     property int fontSize: Global.fontM
-    property real borderRadius: Global.buttonRadius
+    property real borderRadius: Global.buttonBorderRadius
     property string utf8Code: "\uf071"
 
     background: Rectangle {

--- a/Components/LoginControls.qml
+++ b/Components/LoginControls.qml
@@ -1,7 +1,6 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
-import SddmComponents 2.0
+import QtQuick
+import QtQuick.Layouts
 
 Item {
     id: root

--- a/Components/PasswordField.qml
+++ b/Components/PasswordField.qml
@@ -1,7 +1,6 @@
 import ".."
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
-import SddmComponents 2.0
+import QtQuick
+import QtQuick.Layouts
 
 Rectangle {
     id: root
@@ -68,7 +67,7 @@ Rectangle {
             text: ""
             onAccepted: sddm.login(cachedUsers[userIndex].name, passwordField.text, Global.currentSessionIndex)
             Layout.fillWidth: true
-            Keys.onPressed: {
+            Keys.onPressed: (event) => {
                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                     sddm.login(cachedUsers[userIndex].name, passwordField.text, Global.currentSessionIndex);
                     event.accepted = true;

--- a/Components/UserAvatar.qml
+++ b/Components/UserAvatar.qml
@@ -1,7 +1,6 @@
 import ".."
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import SddmComponents 2.0
+import QtQuick
+import QtQuick.Effects
 
 Item {
     id: avatar
@@ -34,6 +33,7 @@ Item {
         anchors.fill: parent
         radius: width / 2
         visible: false
+        layer.enabled: true
     }
 
     Image {
@@ -53,7 +53,8 @@ Item {
         }
         layer.enabled: true
 
-        layer.effect: OpacityMask {
+        layer.effect: MultiEffect {
+            maskEnabled: true
             maskSource: mask
         }
 
@@ -67,7 +68,8 @@ Item {
         visible: avatarImage.status !== Image.Ready
         layer.enabled: true
 
-        layer.effect: OpacityMask {
+        layer.effect: MultiEffect {
+            maskEnabled: true
             maskSource: mask
         }
 

--- a/Components/UserCard.qml
+++ b/Components/UserCard.qml
@@ -1,7 +1,7 @@
 import ".."
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
 
 Rectangle {
     // ========= Public API =========
@@ -112,15 +112,13 @@ Rectangle {
 
     }
 
-    layer.effect: DropShadow {
-        anchors.fill: userCard
-        source: userCard
-        horizontalOffset: 0
-        verticalOffset: 0
-        radius: 16 * Global.scaleFactor
-        samples: 24
-        color: "#40000000"
-        visible: offset === 0 ? true : wheel.isSelecting
+    layer.effect: MultiEffect {
+        shadowEnabled: true
+        shadowColor: "#40000000"
+        shadowHorizontalOffset: 0
+        shadowVerticalOffset: 0
+        shadowBlur: 1.0
+        blurMax: Math.round(16 * Global.scaleFactor)
     }
 
 }

--- a/Components/UserCard.qml
+++ b/Components/UserCard.qml
@@ -61,25 +61,29 @@ Rectangle {
                 Layout.alignment: Qt.AlignVCenter
 
                 Text {
-                    height: 20
+                    Layout.fillWidth: true
                     text: "Welcome back, " + userDisplayName + "!"
                     font.family: Global.font
                     font.pixelSize: Global.fontXXL
                     // font.bold: true
                     font.weight: Font.DemiBold
                     color: Global.mOnSurface
+                    elide: Text.ElideRight
+                    maximumLineCount: 1
                 }
 
                 Text {
                     property color baseColor: Global.mSurfaceVariant
 
-                    height: 20
+                    Layout.fillWidth: true
                     text: Qt.formatDate(new Date(), "dddd, MMMM d")
                     font.family: Global.font
                     font.pixelSize: Global.fontXL
                     font.weight: Font.DemiBold
                     color: Global.mPrimary
                     opacity: 0.6
+                    elide: Text.ElideRight
+                    maximumLineCount: 1
                 }
 
             }

--- a/Components/UserSelector.qml
+++ b/Components/UserSelector.qml
@@ -1,7 +1,6 @@
 import ".."
-import QtGraphicalEffects 1.12
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
 Item {
     // ▲ UP

--- a/Globals.qml
+++ b/Globals.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Window
 pragma Singleton
 
 QtObject {

--- a/Main.qml
+++ b/Main.qml
@@ -1,5 +1,5 @@
-import QtGraphicalEffects 1.12
-import QtQuick 2.15
+import QtQuick
+import QtQuick.Effects
 
 Rectangle {
     id: root
@@ -29,13 +29,13 @@ Rectangle {
         visible: Global.backgroundBlur <= 0
     }
 
-    FastBlur {
+    MultiEffect {
         anchors.fill: parent
         source: wallpaper
-        radius: 20
-        transparentBorder: false
+        blurEnabled: true
+        blur: 1.0
+        blurMax: 32
         visible: Global.backgroundBlur > 0
-        cached: true
     }
 
     UserSelector {

--- a/README.md
+++ b/README.md
@@ -22,18 +22,14 @@ and [Noctalia Dev](https://noctalia.dev/)
 
 > [!NOTE]
 > Theme Dependencies
-> `qt5-graphicaleffects` and `qt5-quickcontrols2`
+> `qt6-declarative` (provides QtQuick, QtQuick.Controls, QtQuick.Effects) and `qt6-svg` (for `.svg` avatars)
 > Misc Dependencies (installer)
 > `jq` - used for handling .json mutations (wallpaper-sync)
 > `awk` - use for handling .conf mutations (installer)
 
 > [!NOTE]
 > If you are using Wayland you might need
-> to also install `qt5-wayland`
-
-### Current W.I.P
-
-- Migrate from qt5 to qt6
+> to also install `qt6-wayland`
 
 ## Installation
 
@@ -121,7 +117,7 @@ sudo chmod 666 "/usr/share/sddm/themes/noctalia/Assets/background.png"
 ## Test theme installation
 
 ```sh
-sddm-greeter --test-mode --theme /usr/share/sddm/themes/noctalia
+sddm-greeter-qt6 --test-mode --theme /usr/share/sddm/themes/noctalia
 ```
 
 ## Configuration

--- a/installer/lib/awk/awk-crud.sh
+++ b/installer/lib/awk/awk-crud.sh
@@ -4,8 +4,17 @@ _ini_tmp() {
   mktemp "${TMPDIR:-/tmp}/ini.XXXXXX"
 }
 
+# Ensure the target file (and its parent dir) exist so awk can read it.
+_ini_ensure_file() {
+  local file=$1
+  [[ -f "$file" ]] && return 0
+  mkdir -p "$(dirname "$file")" && : >"$file"
+}
+
 ini_get() {
   local file=$1 section=$2 key=$3
+
+  [[ -f "$file" ]] || return 0
 
   awk -v section="$section" -v key="$key" '
     BEGIN { FS="="; in_section=0 }
@@ -31,6 +40,8 @@ ini_get() {
 ini_set() {
   local file=$1 section=$2 key=$3 value=$4
   local tmp=$(_ini_tmp)
+
+  _ini_ensure_file "$file"
 
   awk -v section="$section" -v key="$key" -v value="$value" '
     BEGIN { FS="="; in_section=0; seen_section=0; done=0 }
@@ -74,6 +85,8 @@ ini_del() {
   local file=$1 section=$2 key=$3
   local tmp=$(_ini_tmp)
 
+  [[ -f "$file" ]] || return 0
+
   awk -v section="$section" -v key="$key" '
   BEGIN { FS="="; in_section=0 }
     /^\[.*\]$/ {
@@ -93,6 +106,8 @@ ini_del() {
 ini_create_section() {
   local file=$1 section=$2
   local tmp=$(_ini_tmp)
+
+  _ini_ensure_file "$file"
 
   awk -v section="$section" '
     BEGIN { found=0 }
@@ -114,6 +129,9 @@ ini_create_section() {
 ini_remove_section() {
   local file=$1 section=$2
   local tmp=$(_ini_tmp)
+
+  [[ -f "$file" ]] || return 0
+
   awk -v section="$section" '
     BEGIN { skip=0 }
     /^\[.*\]/ {

--- a/installer/lib/utils.sh
+++ b/installer/lib/utils.sh
@@ -12,6 +12,29 @@ run_cmd() {
   fi
 }
 
+# Resolve a user's home directory from the passwd database (robust against
+# non-standard home locations). Defaults to the invoking (sudo) user.
+user_home() {
+  local u="${1:-$SUDO_USER}"
+  [[ -n "$u" ]] || return 1
+  getent passwd "$u" | cut -d: -f6
+}
+
+# True when we have a real non-root invoking user to act on behalf of.
+has_target_user() {
+  [[ -n "$SUDO_USER" && "$SUDO_USER" != "root" ]]
+}
+
+# Run a command as the invoking (non-root) user, preserving correct ownership
+# for anything created under their home directory.
+run_as_user() {
+  if has_target_user; then
+    sudo -u "$SUDO_USER" "$@"
+  else
+    "$@"
+  fi
+}
+
 ask_yes_no() {
   local prompt="$1"
   while true; do

--- a/installer/steps/step_finish.sh
+++ b/installer/steps/step_finish.sh
@@ -3,7 +3,7 @@
 render_header "✅ Installation complete!"
 
 if ask_yes_no "Would you like to test your current theme?"; then
-  run_cmd sudo -u $SUDO_USER sddm-greeter --test-mode --theme $DEST_DIR
+  run_cmd run_as_user sddm-greeter-qt6 --test-mode --theme "$DEST_DIR"
 fi
 
 render_subheader "Goodbye cruel world!"

--- a/installer/steps/step_install_color.sh
+++ b/installer/steps/step_install_color.sh
@@ -1,14 +1,37 @@
 #!/usr/bin/env bash
 
-# TODO: activate noctalia user templates from config
-user_template="/home/$SUDO_USER/.config/noctalia/user-templates.toml"
 render_header "🧩 Installing Noctalia-Shell color sync..."
 
-run_cmd cp "$PROJECT_ROOT/theme.template.conf" $DEST_DIR
+if ! has_target_user; then
+  render_info "No non-root user detected (SUDO_USER unset); skipping color sync setup."
+  return 0
+fi
+
+USER_HOME="$(user_home "$SUDO_USER")"
+if [[ -z "$USER_HOME" ]]; then
+  render_info "Could not resolve home directory for '$SUDO_USER'; skipping color sync setup."
+  return 0
+fi
+
+USER_GROUP="$(id -gn "$SUDO_USER")"
+CONFIG_DIR="$USER_HOME/.config/noctalia"
+user_template="$CONFIG_DIR/user-templates.toml"
+
+# Deploy the color template into the theme, and make the generated theme.conf
+# writable so the shell (running as your user) can render into it.
+run_cmd cp "$PROJECT_ROOT/theme.template.conf" "$DEST_DIR"
 run_cmd chmod 666 "$DEST_DIR/theme.conf"
 
-run_cmd ini_set $user_template templates.sddm input_path "\"$DEST_DIR/theme.template.conf\""
-run_cmd ini_set $user_template templates.sddm output_path "\"$DEST_DIR/theme.conf\""
+# Ensure the noctalia config dir + template file exist, owned by the user
+# (creating them as root would lock Noctalia-Shell out of writing here).
+run_cmd run_as_user mkdir -p "$CONFIG_DIR"
+run_cmd run_as_user touch "$user_template"
 
-run_cmd chown $SUDO_USER $user_template
+# Register the sddm template (input -> output) for Noctalia-Shell to render.
+run_cmd ini_set "$user_template" templates.sddm input_path "\"$DEST_DIR/theme.template.conf\""
+run_cmd ini_set "$user_template" templates.sddm output_path "\"$DEST_DIR/theme.conf\""
+
+# ini_set rewrites via a root-owned temp file, so restore user ownership.
+run_cmd chown -R "$SUDO_USER:$USER_GROUP" "$CONFIG_DIR"
+
 render_info "Remember to activate user-templates in noctalia-shell and refresh your theme to update sddm!"

--- a/installer/steps/step_install_wallpaper.sh
+++ b/installer/steps/step_install_wallpaper.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
-# TODO: automatically add the sync script to noctalia configs
 render_header "🧩 Installing Noctalia-Shell wallpaper sync..."
 
-run_cmd cp "$PROJECT_ROOT/sync-shell-wallpaper.sh" $DEST_DIR
+if ! command -v jq >/dev/null 2>&1; then
+  render_info "jq is required for wallpaper sync but was not found -- install it before using the hook."
+fi
 
-render_info "Add the following script to noctalia hooks and change your wallpaper after"
+run_cmd cp "$PROJECT_ROOT/sync-shell-wallpaper.sh" "$DEST_DIR"
+run_cmd chmod +x "$DEST_DIR/sync-shell-wallpaper.sh"
+
+# The hook runs as your user and overwrites this file in place, so it must be
+# writable by non-root. The sync script preserves this inode/permission.
+run_cmd chmod 666 "$DEST_DIR/Assets/background.png"
+
+render_info "Add the following script to noctalia hooks (Settings > Hooks > Wallpaper changed) and change your wallpaper after:"
 echo "------------------------------------------------"
 echo "$DEST_DIR/sync-shell-wallpaper.sh"
 echo "------------------------------------------------"

--- a/installer/steps/step_sddm_deps.sh
+++ b/installer/steps/step_sddm_deps.sh
@@ -4,9 +4,9 @@ source "$ROOT_DIR/lib/deps.sh"
 DEPENDENCIES=(
   "cmd:sddm"
   "cmd:awk"
-  "cmd:sddm-greeter"
-  "pkg:qt5-quickcontrols2"
-  "pkg:qt5-graphicaleffects"
+  "cmd:sddm-greeter-qt6"
+  "pkg:qt6-declarative"
+  "pkg:qt6-svg"
 )
 
 echo

--- a/installer/steps/step_uninstall.sh
+++ b/installer/steps/step_uninstall.sh
@@ -12,9 +12,14 @@ run_cmd ini_del $SDDM_CONF Theme Current.bak
 run_cmd rm -rf $DEST_DIR
 
 # Deactivate color-sync
-user_template="/home/$SUDO_USER/.config/noctalia/user-templates.toml"
-run_cmd ini_remove_section $user_template templates.sddm
-run_cmd chown $SUDO_USER $user_template
+if has_target_user; then
+  USER_HOME="$(user_home "$SUDO_USER")"
+  user_template="$USER_HOME/.config/noctalia/user-templates.toml"
+  if [[ -f "$user_template" ]]; then
+    run_cmd ini_remove_section "$user_template" templates.sddm
+    run_cmd chown "$SUDO_USER:$(id -gn "$SUDO_USER")" "$user_template"
+  fi
+fi
 
 render_subheader "✅ Theme removed successfuly"
 echo "[NOTE]: Please manually remove the Noctalia-Shell wallpaper hook if previously installed!"

--- a/sync-shell-wallpaper.sh
+++ b/sync-shell-wallpaper.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
+set -uo pipefail
 
 THEME_NAME="noctalia"
-DEST_DIR="/usr/share/sddm/themes/$THEME_NAME/Assets"
+DEST="/usr/share/sddm/themes/$THEME_NAME/Assets/background.png"
 JSON_FILE="$HOME/.cache/noctalia/wallpapers.json"
 
-# wait for wallpaper entry to be changed in json file before reading
+if ! command -v jq >/dev/null 2>&1; then
+  echo "sync-shell-wallpaper: jq is not installed" >&2
+  exit 1
+fi
+
+# Wait for the wallpaper entry to be written to the json before reading it.
 sleep 2
+
+if [[ ! -r "$JSON_FILE" ]]; then
+  echo "sync-shell-wallpaper: cannot read $JSON_FILE" >&2
+  exit 1
+fi
 
 WALLPAPER=$(jq -r '
     if (.wallpapers | length) > 0 then
@@ -21,10 +32,26 @@ WALLPAPER=$(jq -r '
 ' "$JSON_FILE")
 
 if [[ -z "$WALLPAPER" || "$WALLPAPER" == "null" ]]; then
-  echo "No wallpaper found in config"
+  echo "sync-shell-wallpaper: no wallpaper found in config" >&2
   exit 1
 fi
 
-EXT="${WALLPAPER##*.}"
+if [[ ! -r "$WALLPAPER" ]]; then
+  echo "sync-shell-wallpaper: wallpaper source not readable: $WALLPAPER" >&2
+  exit 1
+fi
 
-cp -fa "$WALLPAPER" "$DEST_DIR/background.png"
+if [[ ! -w "$DEST" ]]; then
+  echo "sync-shell-wallpaper: $DEST is not writable." >&2
+  echo "  Run: sudo chmod 666 '$DEST'" >&2
+  exit 1
+fi
+
+# Write in place (via redirect) so the file keeps its existing inode and 0666
+# permissions -- copying would need write access to the root-owned theme dir.
+if cat "$WALLPAPER" >"$DEST"; then
+  echo "sync-shell-wallpaper: updated background from $WALLPAPER"
+else
+  echo "sync-shell-wallpaper: failed to write $DEST" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Completes the "Migrate from qt5 to qt6" item from the README, and fixes several robustness issues in the installer's optional Noctalia-Shell sync along the way.

## Changes

**Qt5 → Qt6 migration**
- Replace `QtGraphicalEffects` (removed in Qt6) with `QtQuick.Effects`: `FastBlur`, `DropShadow`, and `OpacityMask` are reimplemented with `MultiEffect`.
- Drop the unused `SddmComponents` imports and strip version numbers from all `QtQuick` imports (Qt6 idiom).
- Use the `(event) =>` arrow form for `Keys.onPressed`.
- Update dependencies to `qt6-declarative` / `qt6-svg` / `qt6-wayland` and the greeter test command to `sddm-greeter-qt6`, in both the README and the installer.

**Color & wallpaper sync robustness**
- `ini_*` helpers no longer abort when the target file or its parent directory is missing (`awk` couldn't open a nonexistent file, which aborted the installer under `set -e`).
- Color sync creates `~/.config/noctalia/user-templates.toml` as the invoking user and restores ownership after editing, so Noctalia-Shell can write the rendered `theme.conf`.
- Resolve the user's home via `getent` instead of assuming `/home/$USER`, and skip gracefully when there's no non-root user.
- Wallpaper sync writes the background **in place** to preserve the file's `0666` permissions (the old `cp` recreated the file and needed write access to the root-owned theme dir), plus guards for missing `jq`/JSON/source and an unwritable target.
- Installer marks `background.png` writable and the sync script executable.

**Bug fixes surfaced during migration**
- Fix the clock overlapping the username: the welcome/date labels rendered at their natural width and spilled over the clock on long names; they're now constrained with `Layout.fillWidth` and elided.
- `IconButton` referenced a non-existent `Global.buttonRadius` (should be `buttonBorderRadius`), so its corner radius silently fell back to 0.

## ⚠️ Dependency change

This drops the Qt5 runtime deps (`qt5-graphicaleffects`, `qt5-quickcontrols2`) in favor of Qt6 (`qt6-declarative`, `qt6-svg`). Requires an SDDM built against Qt 6.5+ (for `MultiEffect`).

## Testing

- `qmllint` clean across all QML files; `QtQuick.Effects`/`MultiEffect` and every property resolve.
- Theme loads in `sddm-greeter-qt6 --test-mode` without errors.
- Installer scripts pass `bash -n`; verified `ini_set` on a missing file, idempotent re-runs, the in-place wallpaper write preserving inode + `0666`, and a full `--dry-run` of the sync steps.